### PR TITLE
Update nyc and add relevant config as documented

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,11 @@
 {
   "presets": ["es2015", "stage-2"],
-  "plugins": ["transform-es2015-modules-umd"]
+  "plugins": ["transform-es2015-modules-umd"],
+  "env": {
+    "test": {
+      "plugins": [
+        "istanbul"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "prepush": "npm run lint && npm test",
     "compile": "babel src -d dist",
     "ci": "npm run lint && npm run coveralls",
-    "cov": "nyc --reporter=html --reporter=text npm test",
-    "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
+    "cov": "cross-env NODE_ENV=test nyc --reporter=html --reporter=text npm test",
+    "coveralls": "cross-env NODE_ENV=test nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint .",
     "postversion": "git push && git push --tags",
     "test": "mocha",
@@ -31,6 +31,7 @@
   "license": "ISC",
   "devDependencies": {
     "babel-cli": "^6.7.5",
+    "babel-plugin-istanbul": "^1.0.3",
     "babel-plugin-transform-es2015-modules-umd": "^6.6.5",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-2": "^6.11.0",
@@ -39,18 +40,22 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "coveralls": "^2.11.9",
+    "cross-env": "^2.0.0",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-react": "^4.3.0",
     "husky": "^0.11.4",
     "mocha": "^2.4.5",
-    "nyc": "^6.2.1",
+    "nyc": "^7.1.0",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"
   },
   "nyc": {
     "include": [
-      "src/**/*"
-    ]
+      "src/**"
+    ],
+    "sourceMap": false,
+    "instrument": false,
+    "all": true
   }
 }


### PR DESCRIPTION
@saadtazi hope this helps resolve https://github.com/istanbuljs/nyc/issues/329#issuecomment-235143255. Please [let us know if/how we can improve](https://github.com/istanbuljs/istanbuljs.github.io/issues) the [documentation](https://github.com/istanbuljs/nyc#use-with-babel-plugin-istanbul-for-es6es7es2015-support).

Also, friendly suggestion for a simpler set of commands:

``` json
"pretest": "npm run lint",
"test": "cross-env NODE_ENV=test nyc mocha",
"posttest": "nyc report --reporter=lcov"
```

and in `.travis.yml`:

``` yml
after_success: "cat ./coverage/lcov.info | coveralls"
```

instead of the combination of `cov`, `ci`, and `coveralls`.

I would also suggest adding `"check-coverage": true` to the `nyc` config and setting some reasonable thresholds for coverage :)
